### PR TITLE
Version 1.1.0

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1,20 +1,24 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("Nostalgia", "enUS", true)
 
+L["Manual command"] = "Manual command"
+L["Guild Achievement earned"] = "Guild Achievement earned"
+L["Personal Achievement earned"] = "Personal Achievement earned"
+L["Level up"] = "Level up"
+L["Trade completed"] = "Trade completed"
+L["Boss killed: "] = "Boss killed: "
+L["PvP event victory"] = "PvP event victory"
 L["General Settings"] = "General Settings"
 L["About"] = "About"
-L["Take Screenshot on Achievement"] = "Take Screenshot on Achievement"
-L["Enable or disable taking screenshots when you earn an achievement."] =
-    "Enable or disable taking screenshots when you earn an achievement."
+L["Take Screenshot on Personal Achievements"] = "Take Screenshot on Personal Achievements"
+L["Enable or disable taking screenshots when you earn a personal achievement."] =
+    "Enable or disable taking screenshots when you earn a personal achievement."
+L["Take Screenshot on Guild Achievements"] = "Take Screenshot on Guild Achievements"
+L["Enable or disable taking screenshots when your guild earns an achievement."] =
+    "Enable or disable taking screenshots when your guild earns an achievement."
 L["Take Screenshot on Boss Kill"] = "Take Screenshot on Boss Kill"
 L["Enable or disable taking screenshots when you kill a boss."] =
     "Enable or disable taking screenshots when you kill a boss."
-L["Take Screenshot on Rare NPC Kill"] = "Take Screenshot on Rare NPC Kill"
-L["Enable or disable taking screenshots when you kill a rare NPC."] =
-    "Enable or disable taking screenshots when you kill a rare NPC."
 L["Take Screenshot on PvP Event"] = "Take Screenshot on PvP Event"
 L["Enable or disable taking screenshots during PvP events."] = "Enable or disable taking screenshots during PvP events."
 L["Take Screenshot on Level Up"] = "Take Screenshot on Level Up"
 L["Enable or disable taking screenshots when you level up."] = "Enable or disable taking screenshots when you level up."
-L["Take Screenshot on Trade Complete"] = "Take Screenshot on Trade Complete"
-L["Enable or disable taking screenshots when a trade is completed."] =
-    "Enable or disable taking screenshots when a trade is completed."

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -4,23 +4,30 @@ if not L then
     return
 end
 
+L["Manual command"] = "Comando manual"
+L["Guild Achievement earned"] = "Conquista de clã adquirida"
+L["Personal Achievement earned"] = "Conquista pessoal adquirida"
+L["Level up"] = "Subiu de nível"
+L["Trade completed"] = "Negociação completa"
+L["Boss killed: "] = "Chefe morto: "
+L["PvP event victory"] = "Evento JxJ vencido"
 L["General Settings"] = "Configurações Gerais"
 L["About"] = "Sobre"
+L["Take Screenshot on Personal Achievements"] = "Capturar a tela quando adquirir uma conquista pessoal"
+L["Enable or disable taking screenshots when you earn a personal achievement."] =
+    "Ativa ou desativa a captura de tela quando você obtiver uma conquista pessoal."
+L["Take Screenshot on Guild Achievements"] = "Capturar a tela quando seu clã adquirir uma conquista"
+L["Enable or disable taking screenshots when your guild earns an achievement."] =
+    "Ativa ou desativa a captura de tela quando o seu clã obtiver uma conquista."
 L["Take Screenshot on Achievement"] = "Capturar a tela quando adquirir uma conquista"
 L["Enable or disable taking screenshots when you earn an achievement."] =
     "Ativa ou desativa a captura de tela quando você adquirir uma conquista"
 L["Take Screenshot on Boss Kill"] = "Capturar a tela quando matar um chefe"
 L["Enable or disable taking screenshots when you kill a boss."] =
     "Ativa ou desativa a captura de tela quando você matar um chefe de masmorra ou raide"
-L["Take Screenshot on Rare NPC Kill"] = "Capturar a tela quando matar um PNJ Raro"
-L["Enable or disable taking screenshots when you kill a rare NPC."] =
-    "Ativa ou desativa a captura de tela quando você matar um Personagem Não Jogável Raro"
 L["Take Screenshot on PvP Event"] = "Capturar a tela quando vencer um evento JxJ"
 L["Enable or disable taking screenshots during PvP events."] =
     "Ativa ou desativa a captura de tela quando vencer um evento JxJ"
 L["Take Screenshot on Level Up"] = "Capturar a tela quando subir de nível"
 L["Enable or disable taking screenshots when you level up."] =
     "Ativa ou desativa a captura de tela quando subir de nível"
-L["Take Screenshot on Trade Complete"] = "Capturar a tela ao concluir uma negociação"
-L["Enable or disable taking screenshots when a trade is completed."] =
-    "Ativa ou desativa a captura de tela quando concluir uma negociação"

--- a/Nostalgia.lua
+++ b/Nostalgia.lua
@@ -7,12 +7,11 @@ local Nostalgia = LibStub("AceAddon-3.0"):NewAddon("Nostalgia", "AceConsole-3.0"
 -- Default settings
 local defaults = {
     profile = {
-        achievement = true,
+        personalAchievement = true,
+        guildAchievement = true,
         bossKill = true,
-        rareNPC = true,
         pvpEvent = true,
-        levelUp = true,
-        tradeComplete = true
+        levelUp = true
     }
 }
 
@@ -21,10 +20,16 @@ local function ShowScreenshotMessage(message)
     DEFAULT_CHAT_FRAME:AddMessage(message, 1.0, 1.0, 0.0)
 end
 
--- Function to take a screenshot and show a message
-local function TakeScreenshotAndShowMessage()
+-- Function to take a screenshot and show a message with event origin
+local function TakeScreenshotAndShowMessage(eventType)
     Screenshot() -- Capture the screenshot
-    ShowScreenshotMessage("Screenshot Taken!")
+    ShowScreenshotMessage("Screenshot taken: " .. eventType)
+end
+
+-- Function to check if the player is in a battleground or arena
+local function IsInPvPInstance()
+    local inInstance, instanceType = IsInInstance()
+    return inInstance and (instanceType == "pvp" or instanceType == "arena")
 end
 
 -- Register events and handlers
@@ -35,64 +40,64 @@ function Nostalgia:OnInitialize()
     self:RegisterChatCommand(
         "nostalgia",
         function()
-            TakeScreenshotAndShowMessage()
+            TakeScreenshotAndShowMessage(L["Manual command"])
         end
     )
 
     -- Event listeners
     self:RegisterEvent(
         "ACHIEVEMENT_EARNED",
-        function()
-            if self.db.profile.achievement then
-                TakeScreenshotAndShowMessage()
+        function(_, achievementID)
+            local isGuildAchievement = select(12, GetAchievementInfo(achievementID))
+            if isGuildAchievement then
+                if Nostalgia.db.profile.guildAchievement then
+                    TakeScreenshotAndShowMessage(L["Guild Achievement earned"])
+                end
+            else
+                if Nostalgia.db.profile.personalAchievement then
+                    TakeScreenshotAndShowMessage(L["Personal Achievement earned"])
+                end
             end
         end
     )
+
     self:RegisterEvent(
         "PLAYER_LEVEL_UP",
         function()
             if self.db.profile.levelUp then
-                TakeScreenshotAndShowMessage()
-            end
-        end
-    )
-    self:RegisterEvent(
-        "TRADE_SHOW",
-        function()
-            if self.db.profile.tradeComplete then
-                TakeScreenshotAndShowMessage()
+                TakeScreenshotAndShowMessage(L["Level up"])
             end
         end
     )
 
-    -- Combat log event for boss kills, rare NPCs, and PvP
+    -- Event listener for boss kills using ENCOUNTER_END
+    self:RegisterEvent(
+        "ENCOUNTER_END",
+        function(_, encounterID, encounterName, difficultyID, raidSize, endStatus)
+            if self.db.profile.bossKill and endStatus == 1 then
+                TakeScreenshotAndShowMessage(L["Boss killed: "] .. encounterName)
+            end
+        end
+    )
+
+    -- Combat log event for PvP
     self:RegisterEvent(
         "COMBAT_LOG_EVENT_UNFILTERED",
         function()
-            local _, subEvent, _, _, _, _, _, destGUID = CombatLogGetCurrentEventInfo()
-            if subEvent == "UNIT_DIED" and IsEncounterInProgress() and self.db.profile.bossKill then
-                TakeScreenshotAndShowMessage()
-            elseif subEvent == "RARE_KILL" and self.db.profile.rareNPC then
-                TakeScreenshotAndShowMessage()
-            elseif subEvent == "PARTY_KILL" and self.db.profile.pvpEvent then
-                TakeScreenshotAndShowMessage()
+            local _, subEvent, _, _, _, _, _, destGUID, destName = CombatLogGetCurrentEventInfo()
+            local eventType = nil
+
+            -- PvP event detection (e.g., Battleground or Arena victory)
+            if subEvent == "PARTY_KILL" then
+                if IsInPvPInstance() and self.db.profile.pvpEvent then
+                    eventType = L["PvP event victory"]
+                end
+            end
+
+            -- If any event was detected, take a screenshot
+            if eventType then
+                TakeScreenshotAndShowMessage(eventType)
             end
         end
     )
-end
-
--- Include the options module
-Nostalgia:RegisterEvent(
-    "PLAYER_LOGIN",
-    function()
-        if not Nostalgia.optionsLoaded then
-            -- Load options from NostalgiaOptions.lua
-            Nostalgia:LoadOptions()
-            Nostalgia.optionsLoaded = true
-        end
-    end
-)
-
-function Nostalgia:LoadOptions()
-    -- This function will not call SetupOptions
 end

--- a/Nostalgia.lua
+++ b/Nostalgia.lua
@@ -15,6 +15,8 @@ local defaults = {
     }
 }
 
+local L = LibStub("AceLocale-3.0"):GetLocale("Nostalgia")
+
 -- Function to display a message in the chat
 local function ShowScreenshotMessage(message)
     DEFAULT_CHAT_FRAME:AddMessage(message, 1.0, 1.0, 0.0)

--- a/Nostalgia.toc
+++ b/Nostalgia.toc
@@ -1,9 +1,9 @@
-## Interface: 110000
+## Interface: 110002
 ## Title: Nostalgia
 ## Notes: Takes a screenshot everytime you get an achievement
 ## Notes-ptBR: Salva uma captura de tela toda conquista que você adquirir
 ## Author: Ítalo Barboza
-## Version: 1.0.0
+## Version: 1.1.0
 ## IconTexture: Interface\AddOns\Nostalgia\Media\nostalgia_icon
 ## SavedVariables: NostalgiaDB
 

--- a/NostalgiaOptions.lua
+++ b/NostalgiaOptions.lua
@@ -18,18 +18,31 @@ local options = {
             name = L["General Settings"],
             order = 1,
             args = {
-                achievement = {
+                personalAchievement = {
                     type = "toggle",
-                    name = L["Take Screenshot on Achievement"],
-                    desc = L["Enable or disable taking screenshots when you earn an achievement."],
-                    get = function()
-                        return Nostalgia.db.profile.achievement
+                    name = L["Take Screenshot on Personal Achievements"],
+                    desc = L["Enable or disable taking screenshots when you earn a personal achievement."],
+                    get = function(info)
+                        return Nostalgia.db.profile.personalAchievement
                     end,
-                    set = function(_, value)
-                        Nostalgia.db.profile.achievement = value
+                    set = function(info, value)
+                        Nostalgia.db.profile.personalAchievement = value
                     end,
-                    order = 1,
-                    width = "full"
+                    width = "full",
+                    order = 1
+                },
+                guildAchievement = {
+                    type = "toggle",
+                    name = L["Take Screenshot on Guild Achievements"],
+                    desc = L["Enable or disable taking screenshots when your guild earns an achievement."],
+                    get = function(info)
+                        return Nostalgia.db.profile.guildAchievement
+                    end,
+                    set = function(info, value)
+                        Nostalgia.db.profile.guildAchievement = value
+                    end,
+                    width = "full",
+                    order = 2
                 },
                 bossKill = {
                     type = "toggle",
@@ -40,19 +53,6 @@ local options = {
                     end,
                     set = function(_, value)
                         Nostalgia.db.profile.bossKill = value
-                    end,
-                    order = 2,
-                    width = "full"
-                },
-                rareNPC = {
-                    type = "toggle",
-                    name = L["Take Screenshot on Rare NPC Kill"],
-                    desc = L["Enable or disable taking screenshots when you kill a rare NPC."],
-                    get = function()
-                        return Nostalgia.db.profile.rareNPC
-                    end,
-                    set = function(_, value)
-                        Nostalgia.db.profile.rareNPC = value
                     end,
                     order = 3,
                     width = "full"
@@ -80,20 +80,7 @@ local options = {
                     set = function(_, value)
                         Nostalgia.db.profile.levelUp = value
                     end,
-                    order = 6,
-                    width = "full"
-                },
-                tradeComplete = {
-                    type = "toggle",
-                    name = L["Take Screenshot on Trade Complete"],
-                    desc = L["Enable or disable taking screenshots when a trade is completed."],
-                    get = function()
-                        return Nostalgia.db.profile.tradeComplete
-                    end,
-                    set = function(_, value)
-                        Nostalgia.db.profile.tradeComplete = value
-                    end,
-                    order = 7,
+                    order = 5,
                     width = "full"
                 }
             }


### PR DESCRIPTION
- Fix for Rare NPC Kill
- Temporarily removed Trade Screenshot capture
- Temporarily removed Rare Mob Kill
- Broken Achievements in two groups: Personal and/or Guild.
- Now it shows a message on the chat (only for your) with the reason that the capture was made.
- Bump to 11.0.2 game version.