### PR TITLE
update screenshot timers

### DIFF
--- a/Nostalgia.lua
+++ b/Nostalgia.lua
@@ -24,8 +24,10 @@ end
 
 -- Function to take a screenshot and show a message with event origin
 local function TakeScreenshotAndShowMessage(eventType)
-    Screenshot() -- Capture the screenshot
-    ShowScreenshotMessage("Screenshot taken: " .. eventType)
+    C_Timer.After(2, function() 
+        Screenshot() -- Capture the screenshot
+        ShowScreenshotMessage("Screenshot taken: " .. eventType)
+    end)
 end
 
 -- Function to check if the player is in a battleground or arena


### PR DESCRIPTION
There are several instances where the screenshot happens before the achievement pops up. Setting a timer to wait for 2 seconds after the event happens ensures that the popup is visible during the screenshot

to reproduce, you can go to any mythic boss encounter that you dont have an achievement for, and kill it. youll see that the screenshot happens before the popup:

![WoWScrnShot_070225_131515](https://github.com/user-attachments/assets/0c10d5d9-34a8-432a-87c6-510ef720f4eb)
